### PR TITLE
Fix signing issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ class TrezorKeyring extends EventEmitter {
   }
 
   signMessage (withAccount, data) {
-    throw new Error('Not supported on this device')
+    return this.signPersonalMessage (withAccount, data);
   }
 
   // For personal_sign, we need to prefix the message:

--- a/index.js
+++ b/index.js
@@ -216,10 +216,10 @@ class TrezorKeyring extends EventEmitter {
       this.unlock()
           .then(status => {
             setTimeout(_ => {
-              const humanReadableMsg = this._toAscii(message)
               TrezorConnect.ethereumSignMessage({
                 path: this._pathFromAddress(withAccount),
-                message: humanReadableMsg,
+                message: ethUtil.stripHexPrefix(message),
+                hex: true
               }).then(response => {
                 if (response.success) {
                   if (response.payload.address !== ethUtil.toChecksumAddress(withAccount)) {
@@ -291,20 +291,6 @@ class TrezorKeyring extends EventEmitter {
       throw new Error('Unknown address')
     }
     return `${this.hdPath}/${index}`
-  }
-
-  _toAscii (hex) {
-      let str = ''
-      let i = 0; const l = hex.length
-      if (hex.substring(0, 2) === '0x') {
-          i = 2
-      }
-      for (; i < l; i += 2) {
-          const code = parseInt(hex.substr(i, 2), 16)
-          str += String.fromCharCode(code)
-      }
-
-      return str
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ class TrezorKeyring extends EventEmitter {
   }
 
   signMessage (withAccount, data) {
-    return this.signPersonalMessage (withAccount, data);
+    return this.signPersonalMessage(withAccount, data)
   }
 
   // For personal_sign, we need to prefix the message:
@@ -219,7 +219,7 @@ class TrezorKeyring extends EventEmitter {
               TrezorConnect.ethereumSignMessage({
                 path: this._pathFromAddress(withAccount),
                 message: ethUtil.stripHexPrefix(message),
-                hex: true
+                hex: true,
               }).then(response => {
                 if (response.success) {
                   if (response.payload.address !== ethUtil.toChecksumAddress(withAccount)) {

--- a/index.js
+++ b/index.js
@@ -243,11 +243,11 @@ class TrezorKeyring extends EventEmitter {
 
   signTypedData (withAccount, typedData) {
     // Waiting on trezor to enable this
-    throw new Error('Not supported on this device')
+    return Promise.reject(new Error('Not supported on this device'))
   }
 
   exportAccount (address) {
-    throw new Error('Not supported on this device')
+    return Promise.reject(new Error('Not supported on this device'))
   }
 
   forgetDevice () {

--- a/index.js
+++ b/index.js
@@ -62,11 +62,10 @@ class TrezorKeyring extends EventEmitter {
             this.hdk.chainCode = new Buffer(response.payload.chainCode, 'hex')
             resolve('just unlocked')
           } else {
-            reject(response.payload && response.payload.error || 'Unknown error')
+            reject(new Error(response.payload && response.payload.error || 'Unknown error'))
           }
         }).catch(e => {
-          console.log('Error while trying to get public keys ', e)
-          reject(e && e.toString() || 'Unknown error')
+          reject(new Error(e && e.toString() || 'Unknown error'))
         })
     })
   }
@@ -182,17 +181,16 @@ class TrezorKeyring extends EventEmitter {
                   const addressSignedWith = ethUtil.toChecksumAddress(`0x${signedTx.from.toString('hex')}`)
                   const correctAddress = ethUtil.toChecksumAddress(address)
                   if (addressSignedWith !== correctAddress) {
-                    reject('signature doesnt match the right address')
+                    reject(new Error('signature doesnt match the right address'))
                   }
 
                   resolve(signedTx)
                 } else {
-                  reject(response.payload && response.payload.error || 'Unknown error')
+                  reject(new Error(response.payload && response.payload.error || 'Unknown error'))
                 }
 
               }).catch(e => {
-                console.log('Error while trying to sign transaction ', e)
-                reject(e && e.toString() || 'Unknown error')
+                reject(new Error(e && e.toString() || 'Unknown error'))
               })
 
             // This is necessary to avoid popup collision
@@ -200,8 +198,7 @@ class TrezorKeyring extends EventEmitter {
             }, status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0)
 
           }).catch(e => {
-            console.log('Error while trying to sign transaction ', e)
-            reject(e && e.toString() || 'Unknown error')
+            reject(new Error(e && e.toString() || 'Unknown error'))
           })
       })
   }
@@ -223,23 +220,23 @@ class TrezorKeyring extends EventEmitter {
               }).then(response => {
                 if (response.success) {
                   if (response.payload.address !== ethUtil.toChecksumAddress(withAccount)) {
-                    reject('signature doesnt match the right address')
+                    reject(new Error('signature doesnt match the right address'))
                   }
                   const signature = `0x${response.payload.signature}`
                   resolve(signature)
                 } else {
-                  reject(response.payload && response.payload.error || 'Unknown error')
+                  reject(new Error(response.payload && response.payload.error || 'Unknown error'))
                 }
               }).catch(e => {
                 console.log('Error while trying to sign a message ', e)
-                reject(e && e.toString() || 'Unknown error')
+                reject(new Error(e && e.toString() || 'Unknown error'))
               })
             // This is necessary to avoid popup collision
             // between the unlock & sign trezor popups
             }, status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0)
           }).catch(e => {
             console.log('Error while trying to sign a message ', e)
-            reject(e && e.toString() || 'Unknown error')
+            reject(new Error(e && e.toString() || 'Unknown error'))
           })
     })
   }

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -348,18 +348,24 @@ describe('TrezorKeyring', function () {
     })
 
     describe('signTypedData', function () {
-        it('should throw an error because it is not supported', function () {
-            expect(_ => {
-                keyring.signTypedData()
-            }).to.throw('Not supported on this device')
+        it('should throw an error because it is not supported', async function () {
+            try {
+                await keyring.signTypedData()
+            } catch (e) {
+                expect(e instanceof Error, true)
+                expect(e.toString(), 'Not supported on this device')
+            }
         })
     })
 
     describe('exportAccount', function () {
-        it('should throw an error because it is not supported', function () {
-            expect(_ => {
-                keyring.exportAccount()
-            }).to.throw('Not supported on this device')
+        it('should throw an error because it is not supported', async function () {
+            try {
+                await keyring.exportAccount()
+            } catch (e) {
+                expect(e instanceof Error, true)
+                expect(e.toString(), 'Not supported on this device')
+            }
         })
     })
 

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -349,23 +349,29 @@ describe('TrezorKeyring', function () {
 
     describe('signTypedData', function () {
         it('should throw an error because it is not supported', async function () {
+            let error = null
             try {
                 await keyring.signTypedData()
             } catch (e) {
-                expect(e instanceof Error, true)
-                expect(e.toString(), 'Not supported on this device')
+                error = e
             }
+
+            expect(error instanceof Error, true)
+            expect(error.toString(), 'Not supported on this device')
         })
     })
 
     describe('exportAccount', function () {
         it('should throw an error because it is not supported', async function () {
+            let error = null
             try {
                 await keyring.exportAccount()
             } catch (e) {
-                expect(e instanceof Error, true)
-                expect(e.toString(), 'Not supported on this device')
+                error = e
             }
+
+            expect(error instanceof Error, true)
+            expect(error.toString(), 'Not supported on this device')
         })
     })
 

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -319,21 +319,29 @@ describe('TrezorKeyring', function () {
     })
 
     describe('signMessage', function () {
-        it('should throw an error because it is not supported', function () {
-            expect(_ => {
-                keyring.signMessage()
-            }).to.throw('Not supported on this device')
+        it('should call TrezorConnect.ethereumSignMessage', function (done) {
+            const sandbox = chai.spy.sandbox()
+            sandbox.on(TrezorConnect, 'ethereumSignMessage')
+            keyring.signMessage(fakeAccounts[0], 'some msg').catch(e => {
+                // we expect this to be rejected because
+                // we are trying to open a popup from node
+                expect(TrezorConnect.ethereumSignMessage).to.have.been.called()
+                sandbox.restore()
+                done()
+            })
         })
     })
 
     describe('signPersonalMessage', function () {
         it('should call TrezorConnect.ethereumSignMessage', function (done) {
 
-            chai.spy.on(TrezorConnect, 'ethereumSignMessage')
+            const sandbox = chai.spy.sandbox()
+            sandbox.on(TrezorConnect, 'ethereumSignMessage')
             keyring.signPersonalMessage(fakeAccounts[0], 'some msg').catch(e => {
                 // we expect this to be rejected because
                 // we are trying to open a popup from node
                 expect(TrezorConnect.ethereumSignMessage).to.have.been.called()
+                sandbox.restore()
                 done()
             })
         })


### PR DESCRIPTION
Context: Not so long ago trezor started accepting hex data via `TrezorConnect.ethereumSignMessage`

This allow us to solve two different issues:

- Inability of sign UTF8 chars using `personalSign` -  Until now we were forced to convert the string to sign to ASCII before signing, which will cause to sign a different string that will break signature verification process. We fixed this by sending the original UTF-8 string as hex, which is now decoded correctly in the Trezor side.  

Fixes the trezor part of https://github.com/MetaMask/metamask-extension/issues/5523

_NOTE:  The device still doesn't have the ability to render UTF-8 chars but the feature still works._

![utf8](https://user-images.githubusercontent.com/1247834/55351552-aa403500-548c-11e9-966d-daa1c9126263.gif)

- Enable `eth_sign`, which allows to sign a hex message


DEMO of `eth_sign` working  at: https://danfinlay.github.io/js-eth-personal-sign-examples/

![demo](https://user-images.githubusercontent.com/1247834/55351234-c394b180-548b-11e9-9fbc-3a161f80eb32.gif)

Fixes https://github.com/MetaMask/metamask-extension/issues/5218

Additionally I fixed all the rejections which were not returning an error but a string,  which prevented dapps to handle the rejection correctly. 

This fixes :
- the Trezor part of https://github.com/MetaMask/metamask-extension/issues/6070 
- https://github.com/MetaMask/metamask-extension/issues/5052

DEMO of correct rejection on unsupported `signedTypedData`  method after fix:
![rejection](https://user-images.githubusercontent.com/1247834/55353218-c2b24e80-5490-11e9-8f6c-01a4287104d1.gif)

