### PR TITLE
Use strict assert

### DIFF
--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -2,7 +2,7 @@ global.window = require('./window.shim')
 global.navigator = require('./navigator.shim')
 global.self = require('./self.shim')
 
-const assert = require('assert')
+const assert = require('assert').strict
 const chai = require('chai')
 const spies = require('chai-spies')
 const EthereumTx = require('ethereumjs-tx')


### PR DESCRIPTION
This PR updates the test suite to use [the strict mode of assert](https://nodejs.org/docs/latest-v10.x/api/assert.html#assert_strict_mode).