### PR TITLE
Omit test files from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "eth-trezor-keyring",
   "version": "0.5.0",
   "description": "A MetaMask compatible keyring, for trezor hardware wallets",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
The `files` property has been added to the package manifest to restrict which files are included in the published package. Tests and CI configuration are now omitted.