### PR TITLE
Remove unused `events` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eth-sig-util": "^1.4.2",
     "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^5.1.5",
-    "events": "^2.0.0",
     "hdkey": "0.8.0",
     "sinon": "^9.2.3",
     "trezor-connect": "^8.1.19-extended"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1122,10 +1122,6 @@ ethjs-util@^0.1.3:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
 
-events@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
-
 events@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.2.0.tgz#93b87c18f8efcd4202a461aec4dfc0556b639379"


### PR DESCRIPTION
`events` is a [built-in module](https://nodejs.org/docs/latest-v10.x/api/events.html)in Node.js, so we don't need to include the `events` library among our dependencies. The Node.js module resolution algorithm [prefers built-in modules over those in `node_modules`](https://nodejs.org/docs/latest-v10.x/api/modules.html#modules_all_together), so in practice this library was never used.

It's common for the `events` package to be used in non-Node.js environments, like the browser. However we aren't producing a build for non-Node.js environments at the moment, so we have no use for this package. Any downstream projects can use their own bundlers to substitute the built-in module with the `events` package.