### PR TITLE
Pin version of trezor-connect to 8.1.9-extended to avoid installation issues upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^5.1.5",
     "hdkey": "0.8.0",
-    "trezor-connect": "^8.1.19-extended"
+    "trezor-connect": "8.1.19-extended"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-trezor-keyring",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A MetaMask compatible keyring, for trezor hardware wallets",
   "files": [
     "index.js"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,7 +2435,7 @@ to-fast-properties@^2.0.0:
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
 
-trezor-connect@^8.1.19-extended:
+trezor-connect@8.1.19-extended:
   version "8.1.19-extended"
   resolved "https://registry.yarnpkg.com/trezor-connect/-/trezor-connect-8.1.19-extended.tgz#2b5f7f232f2064121f9b3adc05cbf2bc2f7c08cc"
   integrity sha512-elm4fgPB79q5e+q8/i7pW2ms3mwkSQjYrgUD2nV40yP4cP8Cp7DYtu0bh4ZYhMNN0+BFwIYw86fvPSCo6D7OQA==


### PR DESCRIPTION
This should help avoid semver problems in the metamask-extension repo