### PR TITLE
Allow multiple Trezor accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,17 +78,17 @@ class TrezorKeyring extends EventEmitter {
   }
 
   addAccounts (n = 1) {
-
     return new Promise((resolve, reject) => {
       this.unlock()
         .then((_) => {
           const from = this.unlockedAccount
           const to = from + n
-          this.accounts = []
 
           for (let i = from; i < to; i++) {
             const address = this._addressFromIndex(pathBase, i)
-            this.accounts.push(address)
+            if (!this.accounts.includes(address)) {
+              this.accounts.push(address)
+            }
             this.page = 0
           }
           resolve(this.accounts)
@@ -159,7 +159,6 @@ class TrezorKeyring extends EventEmitter {
 
   // tx is an instance of the ethereumjs-transaction class.
   signTransaction (address, tx) {
-
     return new Promise((resolve, reject) => {
       this.unlock()
         .then((status) => {

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -165,6 +165,15 @@ describe('TrezorKeyring', function () {
             done()
           })
       })
+
+      it('returns the custom accounts desired', async function () {
+        keyring.setAccountToUnlock(0)
+        await keyring.addAccounts()
+        keyring.setAccountToUnlock(2)
+        const accounts = await keyring.addAccounts()
+        assert.equal(accounts[0], fakeAccounts[0])
+        assert.equal(accounts[1], fakeAccounts[2])
+      })
     })
 
     describe('with a numeric argument', function () {
@@ -202,6 +211,22 @@ describe('TrezorKeyring', function () {
             assert.equal(accountsAfterRemoval.length, 0)
             done()
           })
+      })
+
+      it('should remove only the account requested', async function () {
+        keyring.setAccountToUnlock(0)
+        await keyring.addAccounts()
+        keyring.setAccountToUnlock(1)
+        await keyring.addAccounts()
+        
+        let accounts = await keyring.getAccounts()
+        assert.equal(accounts.length, 2)
+
+        keyring.removeAccount(fakeAccounts[0])
+        accounts = await keyring.getAccounts()
+        
+        assert.equal(accounts.length, 1)
+        assert.equal(accounts[0], fakeAccounts[1])
       })
     })
 


### PR DESCRIPTION
`addAccounts` was emptying our accounts array, thus preventing multiple accounts from being supported.