### PR TITLE
Receive only production updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,10 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    allow: 
+      - dependency-type: "production"
     schedule:
       interval: "daily"
       time: "06:00"
     versioning-strategy: "increase-if-necessary"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5


### PR DESCRIPTION
We've decided we don't want test library and other non-critical changes.