### PR TITLE
Move `ethereumjs-tx` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^3.1.4",
-    "ethereumjs-tx": "^1.3.4",
     "ethereumjs-util": "^7.0.9",
     "hdkey": "0.8.0",
     "trezor-connect": "8.1.23-extended"
@@ -52,6 +51,7 @@
     "eslint-plugin-mocha": "^8.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.0",
+    "ethereumjs-tx": "^1.3.4",
     "mocha": "^5.0.4",
     "prettier": "^2.3.0",
     "prettier-plugin-packagejson": "^2.2.12",


### PR DESCRIPTION
This library is now only used for tests. In the non-test code, it has been replaced by `@ethereumjs/tx`.