### PR TITLE
Add method for setting the hdpath

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,12 +346,12 @@ class TrezorKeyring extends EventEmitter {
   }
 
   /**
-   * Sets the hdPath property to the passed param, if it is an explicitly supported hdPath.
-   * If the passed param is equal to the current hdPath, then this method has no effect. If it
-   * is different, the hdPath is updated, and the hdk, accounts, page and perPage properties are
-   * reset.
+   * Set the HD path to be used by the keyring. Only known supported HD paths are allowed.
+   * 
+   * If the given HD path is already the current HD path, nothing happens. Otherwise the new HD
+   * path is set, and the wallet state is completely reset.
    *
-   * If the passed hdPath is not explicitly supported, an error is thrown.
+   * @throws {Error] Throws if the HD path is not supported.
    *
    * @param {string} hdPath - The HD path to set.
    */

--- a/index.js
+++ b/index.js
@@ -354,7 +354,6 @@ class TrezorKeyring extends EventEmitter {
    * If the passed hdPath is not explicitly supported, an error is thrown.
    *
    * @param {string} hdPath - The HD path to set.
-   * @returns undefined
    */
   setHdPath(hdPath) {
     if (!ALLOWED_HD_PATHS[hdPath]) {

--- a/index.js
+++ b/index.js
@@ -353,7 +353,7 @@ class TrezorKeyring extends EventEmitter {
    *
    * If the passed hdPath is not explicitly supported, an error is thrown.
    *
-   * @param {string} hdPath
+   * @param {string} hdPath - The HD path to set.
    * @returns undefined
    */
   setHdPath(hdPath) {

--- a/index.js
+++ b/index.js
@@ -345,19 +345,21 @@ class TrezorKeyring extends EventEmitter {
     this.paths = {};
   }
 
-  setHdPath (hdPath) {
+  setHdPath(hdPath) {
     if (!ALLOWED_HD_PATHS[hdPath]) {
-      throw new Error(`The setHdPath method does not support setting HD Path to ${hdPath}`)
+      throw new Error(
+        `The setHdPath method does not support setting HD Path to ${hdPath}`,
+      );
     }
 
     // Reset HDKey if the path changes
     if (this.hdPath !== hdPath) {
-      this.hdk = new HDKey()
+      this.hdk = new HDKey();
       this.accounts = [];
       this.page = 0;
       this.perPage = 5;
     }
-    this.hdPath = hdPath
+    this.hdPath = hdPath;
   }
 
   /* PRIVATE METHODS */

--- a/index.js
+++ b/index.js
@@ -347,7 +347,7 @@ class TrezorKeyring extends EventEmitter {
 
   /**
    * Set the HD path to be used by the keyring. Only known supported HD paths are allowed.
-   * 
+   *
    * If the given HD path is already the current HD path, nothing happens. Otherwise the new HD
    * path is set, and the wallet state is completely reset.
    *

--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ const TrezorConnect = require('trezor-connect').default;
 const { TransactionFactory } = require('@ethereumjs/tx');
 
 const hdPathString = `m/44'/60'/0'/0`;
+const SLIP0044TestnetPath = `m/44'/1'/0'/0`;
+
+const ALLOWED_HD_PATHS = {
+  [hdPathString]: true,
+  [SLIP0044TestnetPath]: true,
+};
+
 const keyringType = 'Trezor Hardware';
 const pathBase = 'm';
 const MAX_INDEX = 1000;
@@ -339,6 +346,10 @@ class TrezorKeyring extends EventEmitter {
   }
 
   setHdPath (hdPath) {
+    if (!ALLOWED_HD_PATHS[hdPath]) {
+      throw new Error(`The setHdPath method does not support setting HD Path to ${hdPath}`)
+    }
+
     // Reset HDKey if the path changes
     if (this.hdPath !== hdPath) {
       this.hdk = new HDKey()

--- a/index.js
+++ b/index.js
@@ -338,6 +338,14 @@ class TrezorKeyring extends EventEmitter {
     this.paths = {};
   }
 
+  setHdPath (hdPath) {
+    // Reset HDKey if the path changes
+    if (this.hdPath !== hdPath) {
+      this.hdk = new HDKey()
+    }
+    this.hdPath = hdPath
+  }
+
   /* PRIVATE METHODS */
 
   _normalize(buf) {

--- a/index.js
+++ b/index.js
@@ -368,6 +368,8 @@ class TrezorKeyring extends EventEmitter {
       this.accounts = [];
       this.page = 0;
       this.perPage = 5;
+      this.unlockedAccount = 0;
+      this.paths = {};
     }
     this.hdPath = hdPath;
   }

--- a/index.js
+++ b/index.js
@@ -345,6 +345,17 @@ class TrezorKeyring extends EventEmitter {
     this.paths = {};
   }
 
+  /**
+   * Sets the hdPath property to the passed param, if it is an explicitly supported hdPath.
+   * If the passed param is equal to the current hdPath, then this method has no effect. If it
+   * is different, the hdPath is updated, and the hdk, accounts, page and perPage properties are
+   * reset.
+   *
+   * If the passed hdPath is not explicitly supported, an error is thrown.
+   *
+   * @param {string} hdPath
+   * @returns undefined
+   */
   setHdPath(hdPath) {
     if (!ALLOWED_HD_PATHS[hdPath]) {
       throw new Error(

--- a/index.js
+++ b/index.js
@@ -342,6 +342,9 @@ class TrezorKeyring extends EventEmitter {
     // Reset HDKey if the path changes
     if (this.hdPath !== hdPath) {
       this.hdk = new HDKey()
+      this.accounts = [];
+      this.page = 0;
+      this.perPage = 5;
     }
     this.hdPath = hdPath
   }

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -476,4 +476,47 @@ describe('TrezorKeyring', function () {
       assert.equal(accounts.length, 0);
     });
   });
+
+  describe('setHdPath', function () {
+    const initialProperties = {
+      hdPath: `m/44'/60'/0'/0`,
+      accounts: ['Account 1'],
+      page: 2,
+      perPage: 10,
+    };
+
+    beforeEach(function () {
+      keyring.deserialize(initialProperties);
+    });
+
+    it('should do nothing if passed an hdPath equal to the current hdPath', async function () {
+      keyring.setHdPath(initialProperties.hdPath);
+      assert.equal(keyring.hdPath, initialProperties.hdPath);
+      assert.deepEqual(keyring.accounts, initialProperties.accounts);
+      assert.equal(keyring.page, initialProperties.page);
+      assert.equal(keyring.perPage, initialProperties.perPage);
+      assert.equal(keyring.hdk._publicKey.toString('hex'), fakeHdKey._publicKey.toString('hex'));
+    });
+
+    it('should update the hdPath and reset account and page properties if passed a new hdPath', async function () {
+      const SLIP0044TestnetPath = `m/44'/1'/0'/0`;
+
+      keyring.setHdPath(SLIP0044TestnetPath);
+
+      assert.equal(keyring.hdPath, SLIP0044TestnetPath);
+      assert.deepEqual(keyring.accounts, []);
+      assert.equal(keyring.page, 0);
+      assert.equal(keyring.perPage, 5);
+      assert.equal(keyring.hdk._publicKey, null);
+    });
+
+    it('should throw an error if passed an unsupported hdPath', async function () {
+      const unsupportedPath = 'unsupported hdPath';
+      try {
+        keyring.setHdPath(unsupportedPath);
+      } catch (error) {
+        assert.equal(error.message, `The setHdPath method does not support setting HD Path to ${unsupportedPath}`)
+      }
+    });
+  });
 });

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -495,7 +495,10 @@ describe('TrezorKeyring', function () {
       assert.deepEqual(keyring.accounts, initialProperties.accounts);
       assert.equal(keyring.page, initialProperties.page);
       assert.equal(keyring.perPage, initialProperties.perPage);
-      assert.equal(keyring.hdk._publicKey.toString('hex'), fakeHdKey._publicKey.toString('hex'));
+      assert.equal(
+        keyring.hdk._publicKey.toString('hex'),
+        fakeHdKey._publicKey.toString('hex'),
+      );
     });
 
     it('should update the hdPath and reset account and page properties if passed a new hdPath', async function () {
@@ -515,7 +518,10 @@ describe('TrezorKeyring', function () {
       try {
         keyring.setHdPath(unsupportedPath);
       } catch (error) {
-        assert.equal(error.message, `The setHdPath method does not support setting HD Path to ${unsupportedPath}`)
+        assert.equal(
+          error.message,
+          `The setHdPath method does not support setting HD Path to ${unsupportedPath}`,
+        );
       }
     });
   });

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -484,9 +484,13 @@ describe('TrezorKeyring', function () {
       page: 2,
       perPage: 10,
     };
+    const accountToUnlock = 1;
+    const mockPaths = { '0x123': 1 };
 
     beforeEach(function () {
       keyring.deserialize(initialProperties);
+      keyring.paths = mockPaths;
+      keyring.setAccountToUnlock(accountToUnlock.toString(16));
     });
 
     it('should do nothing if passed an hdPath equal to the current hdPath', async function () {
@@ -499,6 +503,8 @@ describe('TrezorKeyring', function () {
         keyring.hdk._publicKey.toString('hex'),
         fakeHdKey._publicKey.toString('hex'),
       );
+      assert.equal(keyring.unlockedAccount, accountToUnlock);
+      assert.deepEqual(keyring.paths, mockPaths);
     });
 
     it('should update the hdPath and reset account and page properties if passed a new hdPath', async function () {
@@ -511,6 +517,8 @@ describe('TrezorKeyring', function () {
       assert.equal(keyring.page, 0);
       assert.equal(keyring.perPage, 5);
       assert.equal(keyring.hdk._publicKey, null);
+      assert.equal(keyring.unlockedAccount, 0);
+      assert.deepEqual(keyring.paths, {});
     });
 
     it('should throw an error if passed an unsupported hdPath', async function () {


### PR DESCRIPTION
Currently, the trezor keyring controller cannot easily have it's hdpath updated. Making it hard to connect wallets on other chains or which were generated with different hdpaths in other wallets. This PR adds a method, the same as the method we have in the ledger keyring, that allows the client to set the hd path after class instantiation.