### PR TITLE
Fix contract deployments

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,7 +288,11 @@ class TrezorKeyring extends EventEmitter {
     } else {
       // new-style transaction from @ethereumjs/tx package
       // we can just copy tx.toJSON() for everything except chainId, which must be a number
-      transaction = { ...tx.toJSON(), chainId };
+      transaction = {
+        ...tx.toJSON(),
+        chainId,
+        to: this._normalize(tx.to),
+      };
     }
 
     try {


### PR DESCRIPTION
`TrezorConnect.ethereumSignTransaction` will fail if the `to` address is `undefined`, but the `toJSON` method of ethereumjs-tx will return `undefined` when dealing with a transaction intended to deploy a contract. With https://github.com/MetaMask/eth-trezor-keyring/pull/108 we introduced a change which, for EIP-1559 transactions, we were setting the `to` address (and other properties) passed to `TrezorConnect.ethereumSignTransaction` according to the `ethereumjs-tx` `toJSON`. This would result in an error. The fix is to explicitly add a normalized version of the `to` property to the transaction object passed to `ethereumSignTransaction`