### PR TITLE
Expose method to call the TrezorConnect.dispose()

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,13 @@ class TrezorKeyring extends EventEmitter {
     return this.model;
   }
 
+  dispose() {
+    // This removes the Trezor Connect iframe from the DOM
+    // This method is not well documented, but the code it calls can be seen
+    // here: https://github.com/trezor/connect/blob/dec4a56af8a65a6059fb5f63fa3c6690d2c37e00/src/js/iframe/builder.js#L181
+    TrezorConnect.dispose();
+  }
+
   serialize() {
     return Promise.resolve({
       hdPath: this.hdPath,


### PR DESCRIPTION
This PR addresses an error that would occur if MetaMask is locked and then unlocked, when a Trezor account has been added.

While the error was obscured by an issue with Lavamoat, we were able to determine that it was an error being thrown from within TrezorConnect: TypeError: Cannot add property default, object is not extensible

This error is thrown when trying to call TrezorConnect.init (within the trezor keyring constructor) if the Trezor iframe already exists. We instantiate a new Trezor keyring whenever we unlock, so if a user was to lock and unlock without closing the browser, this issue could happen.

The TrezorConnect.dispose method removes the iframe from the dom. This PR exposes that method so that it can be called within MetaMask.

The associated PR in MetaMask is https://github.com/MetaMask/metamask-extension/pull/13018