### PR TITLE
Squashed commit of the following:

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -80,9 +80,9 @@
   integrity sha512-vD2DcC0ffJj1w2y1Lu0OU39wHmlPEd2tCDW04Bm6Kf4LyRnCHCezTsS8yzeSJ+4so7XP+TITuR5FGJRWxPb+GA==
 
 "@metamask/auto-changelog@^2.3.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.5.0.tgz#078f38142a3086fdb5556c758969a015c71dfdc9"
-  integrity sha512-39FeU98Poll3eTqv/bggqo3Yisza0WQJ8l9IiYloMVa2LV8XqTNqVkS4cNEU/5yq62n47JSAv6lZBtWCqeAjZQ==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@metamask/auto-changelog/-/auto-changelog-2.6.1.tgz#5a6291df6c1592f010bd54f1a97814a4570b1eaf"
+  integrity sha512-7VI4lftbQQHbZcxl1W+qFTWHxoeDGybL22Q70SNyYUVIBLlK5PirJHPh1zVYL4jEFmW0rItLLAXd/OZDuVG1Jg==
   dependencies:
     diff "^5.0.0"
     execa "^5.1.1"


### PR DESCRIPTION
commit 06f784881e02cab8567c0551fdd809c794359e56
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Jun 22 06:01:27 2022 +0000

    Bump @metamask/auto-changelog from 2.5.0 to 2.6.1

    Bumps [@metamask/auto-changelog](https://github.com/MetaMask/auto-changelog) from 2.5.0 to 2.6.1.
    - [Release notes](https://github.com/MetaMask/auto-changelog/releases)
    - [Changelog](https://github.com/MetaMask/auto-changelog/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/MetaMask/auto-changelog/compare/v2.5.0...v2.6.1)

    ---
    updated-dependencies:
    - dependency-name: "@metamask/auto-changelog"
      dependency-type: direct:development
      update-type: version-update:semver-minor
    ...

    Signed-off-by: dependabot[bot] <support@github.com>