### PR TITLE
remove quotation mark from build-lint-test workflow name

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,4 +1,4 @@
-name: Build, Lint, and Test"
+name: Build, Lint, and Test
 
 on:
   workflow_call:


### PR DESCRIPTION
A small typo 😅 