### PR TITLE
Add public key check to prevent freezing.

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,7 +477,7 @@ class TrezorKeyring extends EventEmitter {
 
   async _pathFromAddress(address) {
     // First, assert that the pubkey which MetaMask remembers is the same as the one Trezor knows
-    const response = TrezorConnect.getPublicKey({
+    const response = await TrezorConnect.getPublicKey({
       path: this.hdPath,
       coin: 'ETH',
     });

--- a/index.js
+++ b/index.js
@@ -313,7 +313,7 @@ class TrezorKeyring extends EventEmitter {
       const status = await this.unlock();
       await wait(status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0);
       const response = await TrezorConnect.ethereumSignTransaction({
-        path: this._pathFromAddress(address),
+        path: await this._pathFromAddress(address),
         transaction,
       });
       if (response.success) {
@@ -344,51 +344,30 @@ class TrezorKeyring extends EventEmitter {
   }
 
   // For personal_sign, we need to prefix the message:
-  signPersonalMessage(withAccount, message) {
-    return new Promise((resolve, reject) => {
-      this.unlock()
-        .then((status) => {
-          setTimeout(
-            (_) => {
-              TrezorConnect.ethereumSignMessage({
-                path: this._pathFromAddress(withAccount),
-                message: ethUtil.stripHexPrefix(message),
-                hex: true,
-              })
-                .then((response) => {
-                  if (response.success) {
-                    if (
-                      response.payload.address !==
-                      ethUtil.toChecksumAddress(withAccount)
-                    ) {
-                      reject(
-                        new Error('signature doesnt match the right address'),
-                      );
-                    }
-                    const signature = `0x${response.payload.signature}`;
-                    resolve(signature);
-                  } else {
-                    reject(
-                      new Error(
-                        (response.payload && response.payload.error) ||
-                          'Unknown error',
-                      ),
-                    );
-                  }
-                })
-                .catch((e) => {
-                  reject(new Error((e && e.toString()) || 'Unknown error'));
-                });
-              // This is necessary to avoid popup collision
-              // between the unlock & sign trezor popups
-            },
-            status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0,
-          );
-        })
-        .catch((e) => {
-          reject(new Error((e && e.toString()) || 'Unknown error'));
-        });
-    });
+  async signPersonalMessage(withAccount, message) {
+    try {
+      const status = await this.unlock();
+      await wait(status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0);
+      const response = await TrezorConnect.ethereumSignMessage({
+        path: await this._pathFromAddress(withAccount),
+        message: ethUtil.stripHexPrefix(message),
+        hex: true,
+      });
+      if (response.success) {
+        if (
+          response.payload.address !== ethUtil.toChecksumAddress(withAccount)
+        ) {
+          throw new Error("signature doesn't match the right address");
+        }
+        const signature = `0x${response.payload.signature}`;
+        return signature;
+      }
+      throw new Error(
+        (response.payload && response.payload.error) || 'Unknown error',
+      );
+    } catch (e) {
+      throw new Error((e && e.toString()) || 'Unknown error');
+    }
   }
 
   /**
@@ -415,7 +394,7 @@ class TrezorKeyring extends EventEmitter {
     await wait(status === 'just unlocked' ? DELAY_BETWEEN_POPUPS : 0);
 
     const response = await TrezorConnect.ethereumSignTypedData({
-      path: this._pathFromAddress(address),
+      path: await this._pathFromAddress(address),
       data: {
         types: { EIP712Domain, ...otherTypes },
         message,
@@ -496,7 +475,7 @@ class TrezorKeyring extends EventEmitter {
     return ethUtil.toChecksumAddress(`0x${address}`);
   }
 
-  _pathFromAddress(address) {
+  async _pathFromAddress(address) {
     const checksummedAddress = ethUtil.toChecksumAddress(address);
     let index = this.paths[checksummedAddress];
     if (typeof index === 'undefined') {

--- a/test/test-eth-trezor-keyring.js
+++ b/test/test-eth-trezor-keyring.js
@@ -105,6 +105,16 @@ describe('TrezorKeyring', function () {
   beforeEach(async function () {
     keyring = new TrezorKeyring();
     keyring.hdk = fakeHdKey;
+    // mock TrezorConnect.getPubicKey with fake accounts
+    sinon.stub(TrezorConnect, 'getPublicKey').callsFake((_) => {
+      return Promise.resolve({
+        success: true,
+        payload: {
+          publicKey: fakeHdKey.publicKey.toString('hex'),
+          chainCode: fakeHdKey.chainCode.toString('hex'),
+        },
+      });
+    });
   });
 
   afterEach(function () {
@@ -185,9 +195,6 @@ describe('TrezorKeyring', function () {
     });
 
     it('should call TrezorConnect.getPublicKey if we dont have a public key', async function () {
-      sinon
-        .stub(TrezorConnect, 'getPublicKey')
-        .callsFake(() => Promise.resolve({}));
       keyring.hdk = new HDKey();
       try {
         await keyring.unlock();


### PR DESCRIPTION
## Explanation

Fixes MetaMask/metamask-extension#12967 

When MetaMask's selected account are changed, the public key which MetaMask remembers will become different from the one `TrezorKeyring` remembers. Then it searches the address from the incorrect address spaces. Finally it falls into nearly-infinite loop.

So I added the public key check.

To achieve that I made the following changes:
- Make `_pathFromAddress` asynchronous
- Add checking public key is not changed
- Fix test

## Pre-merge author checklist

- [x] I've clearly explained:
  - [x] What problem this PR is solving
  - [x] How this problem was solved
  - [x] How reviewers can test my changes
- [x] Sufficient automated test coverage has been added

## Pre-merge reviewer checklist

- [ ] Manual testing (e.g. pull and build branch, run in browser, test code being changed)
- [ ] PR is linked to the appropriate GitHub issue
- [ ] **IF** this PR fixes a bug in the release milestone, add this PR to the release milestone

If further QA is required (e.g. new feature, complex testing steps, large refactor), add the `Extension QA Board` label.

In this case, a QA Engineer approval will be be required.