### PR TITLE
Delete unused `.yarnrc`

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-ignore-scripts true


### PR DESCRIPTION
We forgot to remove this file when upgrading to Yarn v3