### PR TITLE
chore: Add legacy path

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,8 +43,8 @@ module.exports = {
     global: {
       branches: 44.82,
       functions: 88,
-      lines: 86.93,
-      statements: 87.22,
+      lines: 87,
+      statements: 87.29,
     },
   },
 

--- a/src/trezor-keyring.ts
+++ b/src/trezor-keyring.ts
@@ -28,7 +28,7 @@ const legacyMewPath = `m/44'/60'/0'`;
 
 const ALLOWED_HD_PATHS = {
   [hdPathString]: true,
-  [legacyMewPath]: true
+  [legacyMewPath]: true,
   [SLIP0044TestnetPath]: true,
 } as const;
 

--- a/src/trezor-keyring.ts
+++ b/src/trezor-keyring.ts
@@ -24,9 +24,11 @@ import { hasProperty } from '@metamask/utils';
 
 const hdPathString = `m/44'/60'/0'/0`;
 const SLIP0044TestnetPath = `m/44'/1'/0'/0`;
+const legacyMewPath = `m/44'/60'/0'`;
 
 const ALLOWED_HD_PATHS = {
   [hdPathString]: true,
+  [legacyMewPath]: true
   [SLIP0044TestnetPath]: true,
 } as const;
 


### PR DESCRIPTION
Related PR https://github.com/MetaMask/metamask-extension/pull/19443

Ledger users are migrating to Trezor, directly inputting their recovery phrases into the HWW. OG Ethereum users are unable to access their assets on Trezor to due the 'legacy' [derivation path](https://github.com/MetaMask/metamask-extension/blob/f03f2d3f79ce0c54bbce033cd83cdf9c4f26b363/ui/pages/create-account/connect-hardware/index.js#L37) not available when configuring Trezor.

The Ledger integration offers the same legacy derivation path: https://github.com/MetaMask/metamask-extension/blob/f03f2d3f79ce0c54bbce033cd83cdf9c4f26b363/ui/pages/create-account/connect-hardware/index.js#LL41C1-L41C1

https://www.reddit.com/r/TREZOR/comments/13wy3xz/comment/jmlwqyw/?context=3