### PR TITLE
Rename dispose to destroy

### DIFF
--- a/src/trezor-keyring.test.ts
+++ b/src/trezor-keyring.test.ts
@@ -148,12 +148,12 @@ describe('TrezorKeyring', function () {
     });
   });
 
-  describe('dispose', function () {
+  describe('destroy', function () {
     it('calls dispose on bridge', async function () {
       const disposeStub = sinon.stub().resolves();
       bridge.dispose = disposeStub;
 
-      await keyring.dispose();
+      await keyring.destroy();
 
       expect(disposeStub.calledOnce).toBe(true);
       sinon.assert.calledWithExactly(disposeStub);

--- a/src/trezor-keyring.ts
+++ b/src/trezor-keyring.ts
@@ -123,7 +123,7 @@ export class TrezorKeyring extends EventEmitter {
     });
   }
 
-  dispose() {
+  async destroy() {
     return this.bridge.dispose();
   }
 


### PR DESCRIPTION
This PR renames the `dispose` method to `destroy`, to make it aligned with the Ledger keyring.

## Changes

- **BREAKING**: `dispose` method has been renamed to `destroy`

## References

* Fixes #178 