### PR TITLE
Removing devs from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/engineering
+*                                    @MetaMask/account-management


### PR DESCRIPTION
This PR removes devs from being a codeowner, and instead adds the account-managment team.